### PR TITLE
Added SMat trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-nalgebra-sparse = "0.7.1"
+nalgebra-sparse = "0.8.0"
 ndarray = "0.15.6"
 rand = "0.8.5"
 thiserror = "1.0.37"


### PR DESCRIPTION
- Added `SMat` trait to enable other sparse matrix types.
- Implemented `SMat` for `CscMatrix`, `CsrMatrix`, `CooMatrix`.
- Now avoids transposing the source matrix when it's wide.
- Now avoids allocating a temp vector in `svd_opb`.
- Implemented `SvdRec.recompose()`.